### PR TITLE
deploy 시 compilemessages 작업 추가

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -133,6 +133,11 @@ class AskDjango(object):
                     self.run_cmd('env\scripts\python manage.py collectstatic --settings={django_settings_module} --noinput --clear',
                             django_settings_module=django_settings_module)
 
+                    log('Compiling Django message files.')
+
+                    self.run_cmd('env\scripts\python manage.py compilemessages --settings={django_settings_module}',
+                            django_settings_module=django_settings_module)
+
     def post_python_deployment(self):
         if self.post_deployment_action:
             self.run_cmd(self.post_deployment_action)
@@ -171,4 +176,3 @@ class AskDjango(object):
 
 if __name__ == '__main__':
     AskDjango().run()
-

--- a/deploy_settings.py
+++ b/deploy_settings.py
@@ -9,6 +9,6 @@ assert(PYTHON_VERSION in ('3.4', '2.7'))
 # 가상환경을 env 디렉토리에 이미 생성하셨다면, True로 설정해주세요.
 IS_SKIP_PYTHON_DEPLOYMENT = False
 
-# Azure WebApp 상에서 collectstatic 명령을 수행하지 않으실려면, True로 설정해주세요.
+# Azure WebApp 상에서 collectstatic 및 compilemessages 명령을 수행하지 않으실려면,
+# True로 설정해주세요.
 IS_SKIP_DJANGO_EXTRA = False
-


### PR DESCRIPTION
컴파일된 .mo 파일은 깃에 커밋하지 않는 경우가 많기 때문에, deploy 시 compilemessages 작업을 추가로 수행할 수 있도록 하였습니다.
